### PR TITLE
[HWORKS-2533] Install git in the builder image and add an exception for user permissions

### DIFF
--- a/build_distribution.sh
+++ b/build_distribution.sh
@@ -122,6 +122,15 @@ while (( "$#" )); do
   shift
 done
 
+echo "Installing git"
+
+apt update
+apt install -y git
+
+# Git sets a security requirement that the user running git should match the owner of the files
+# For building it is fine to set an exception
+git config --global --add safe.directory /incubator-uniffle
+
 cd $RSS_HOME
 
 if [ $(command -v git) ]; then


### PR DESCRIPTION

https://hopsworks.atlassian.net/browse/HWORKS-2533

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
